### PR TITLE
Avoid wrong legacy class overriding

### DIFF
--- a/src/LegacyClassLoader.php
+++ b/src/LegacyClassLoader.php
@@ -64,8 +64,16 @@ final class LegacyClassLoader
         );
 
         if ($enableOverrides) {
+            //Iterate locating each core directory inside the override directories
+            $overrideDirectories = [];
+            foreach($this->overrideDirectories as $overrideDirectory){
+                foreach($this->coreDirectories as $coreDirectory){
+                    $overrideDirectories[] = $overrideDirectory.DIRECTORY_SEPARATOR.$coreDirectory;
+                }
+            }
+
             $overrideClasses = $this->parseClasses(
-                $this->loadClasses($this->overrideDirectories)
+                $this->loadClasses($overrideDirectories)
             );
 
             $classes = array_merge($classes, $overrideClasses);


### PR DESCRIPTION
Limiting the directories where the overrides will be looked

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The original code tries to match all the core classes and controllers inside the override folder and subfolders. Inside of this override folder there are classes, controllers and also modules folder. I have an override for a module that contains a Product class with its own namespace, not related anyway with the prestashop core Product class. The autoload original code matched the module product class as an override of the core product class. Limiting the directories to override/classes and override/controllers this bug is solved. A better solution would be to check if the detected override class extends the original class.
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | Osunasport - Berto Ferrero
| How to test?      | Just put inside of the module override folder an override of any module and create a product.php script with a Product class with its own namespace. Autoload will link it as an override of the core Product class
